### PR TITLE
feat: add landing page and routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { AuthProvider, useAuth } from "./hooks/useAuth";
 import Dashboard from "./pages/Dashboard";
 import Auth from "./pages/Auth";
 import NotFound from "./pages/NotFound";
+import Index from "./pages/Index";
 
 const queryClient = new QueryClient();
 
@@ -40,7 +41,7 @@ function PublicRoute({ children }: { children: React.ReactNode }) {
   }
   
   if (user) {
-    return <Navigate to="/" replace />;
+    return <Navigate to="/dashboard" replace />;
   }
   
   return <>{children}</>;
@@ -54,7 +55,8 @@ const App = () => (
         <Sonner />
         <BrowserRouter>
           <Routes>
-            <Route path="/" element={
+            <Route path="/" element={<Index />} />
+            <Route path="/dashboard" element={
               <ProtectedRoute>
                 <Dashboard />
               </ProtectedRoute>

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -18,7 +18,7 @@ export default function Auth() {
 
   // Redirect if already authenticated
   if (user) {
-    navigate('/');
+    navigate('/dashboard');
     return null;
   }
 
@@ -39,7 +39,7 @@ export default function Auth() {
         title: "Success!",
         description: "You have been signed in."
       });
-      navigate('/');
+      navigate('/dashboard');
     }
     
     setLoading(false);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,26 @@
-// Update this page (the content is just a fallback if you fail to update the page)
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
 
 const Index = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (user) {
+      navigate("/dashboard");
+    }
+  }, [user, navigate]);
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">Welcome to Your Blank App</h1>
-        <p className="text-xl text-muted-foreground">Start building your amazing project here!</p>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4">
+      <div className="text-center space-y-6">
+        <h1 className="text-4xl font-bold">ZeroTab</h1>
+        <p className="text-xl text-muted-foreground max-w-md mx-auto">
+          Lightweight AI-enhanced browser decluttering tool to save and organize your tabs.
+        </p>
+        <Button onClick={() => navigate("/auth")}>Get Started</Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add landing page with product overview and auth redirect
- route dashboard to `/dashboard` and adjust auth flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688e87b1fa14832ea34e17638d573b0f