### PR TITLE
fix: improve click delegation and dashboard error handling

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -394,29 +394,58 @@ class ClearTabMindPopup {
 
     // Add event delegation for all actions
     document.addEventListener('click', (e) => {
-      if (e.target.classList.contains('btn-open')) {
-        const url = e.target.getAttribute('data-url');
+      const target = e.target instanceof HTMLElement ? e.target : null;
+      if (!target) return;
+
+      const openBtn = target.closest('.btn-open');
+      if (openBtn) {
+        const url = openBtn.getAttribute('data-url');
         this.openTab(url);
-      } else if (e.target.classList.contains('btn-read')) {
-        const tabId = e.target.getAttribute('data-tab-id');
+        return;
+      }
+
+      const readBtn = target.closest('.btn-read');
+      if (readBtn) {
+        const tabId = readBtn.getAttribute('data-tab-id');
         this.toggleReadStatus(tabId);
-      } else if (e.target.classList.contains('btn-delete')) {
-        const tabId = e.target.getAttribute('data-tab-id');
+        return;
+      }
+
+      const deleteBtn = target.closest('.btn-delete');
+      if (deleteBtn) {
+        const tabId = deleteBtn.getAttribute('data-tab-id');
         this.handleDelete(tabId);
-      } else if (e.target.classList.contains('btn-open-collection')) {
-        const collectionId = e.target.getAttribute('data-collection-id');
+        return;
+      }
+
+      const openCollectionBtn = target.closest('.btn-open-collection');
+      if (openCollectionBtn) {
+        const collectionId = openCollectionBtn.getAttribute('data-collection-id');
         const collection = this.collections.find(c => c.id === collectionId);
         if (collection) {
           this.openCollection(collection);
         }
-      } else if (e.target.classList.contains('btn-delete-collection')) {
-        const collectionId = e.target.getAttribute('data-collection-id');
+        return;
+      }
+
+      const deleteCollectionBtn = target.closest('.btn-delete-collection');
+      if (deleteCollectionBtn) {
+        const collectionId = deleteCollectionBtn.getAttribute('data-collection-id');
         this.handleDeleteCollection(collectionId);
-      } else if (e.target.id === 'loadMoreBtn') {
+        return;
+      }
+
+      if (target.closest('#loadMoreBtn')) {
         this.loadMoreTabs();
-      } else if (e.target.id === 'backBtn') {
+        return;
+      }
+
+      if (target.closest('#backBtn')) {
         this.backToCollections();
-      } else if (e.target.id === 'createCollectionBtn') {
+        return;
+      }
+
+      if (target.closest('#createCollectionBtn')) {
         this.showCreateCollectionDialog();
       }
     });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -70,16 +70,16 @@ export default function Dashboard() {
 
       if (error) throw error;
       setSavedTabs((data || []) as SavedTab[]);
-    } catch (error) {
-      toast({
-        title: "Error loading tabs",
-        description: error.message,
-        variant: "destructive"
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
+      } catch (error: unknown) {
+        toast({
+          title: "Error loading tabs",
+          description: error instanceof Error ? error.message : String(error),
+          variant: "destructive"
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
 
   /**
    * Handles submission of the "Add Tab" form.
@@ -115,14 +115,14 @@ export default function Dashboard() {
 
       setNewTab({ title: '', url: '', tags: '', note: '' });
       loadSavedTabs();
-    } catch (error) {
-      toast({
-        title: "Error saving tab",
-        description: error.message,
-        variant: "destructive"
-      });
-    }
-  };
+      } catch (error: unknown) {
+        toast({
+          title: "Error saving tab",
+          description: error instanceof Error ? error.message : String(error),
+          variant: "destructive"
+        });
+      }
+    };
 
 
   /**
@@ -143,14 +143,14 @@ export default function Dashboard() {
         title: "Tab deleted",
         description: "The tab has been removed."
       });
-    } catch (error) {
-      toast({
-        title: "Error deleting tab",
-        description: error.message,
-        variant: "destructive"
-      });
-    }
-  };
+      } catch (error: unknown) {
+        toast({
+          title: "Error deleting tab",
+          description: error instanceof Error ? error.message : String(error),
+          variant: "destructive"
+        });
+      }
+    };
 
   const filteredTabs = savedTabs.filter(tab => {
     const matchesFilter = filter === 'all' || tab.status === filter;


### PR DESCRIPTION
## Summary
- avoid errors from non-HTMLElement click targets in popup
- allow nested elements within buttons to trigger actions
- safely surface dashboard errors when loading, saving, or deleting tabs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894a4d49b6c832eaf3d47723566544f