### PR TITLE
feat: compact tab list component

### DIFF
--- a/src/components/TabList.tsx
+++ b/src/components/TabList.tsx
@@ -1,0 +1,85 @@
+import { Badge } from '@/components/ui/badge';
+import { useState } from 'react';
+
+export interface TabItem {
+  id: string;
+  title: string;
+  url: string;
+  tags: string[];
+  status: 'unread' | 'read' | 'archived';
+}
+
+interface TabListProps {
+  tabs: TabItem[];
+  onOpen: (url: string) => void;
+  onDelete: (id: string) => void;
+  emptyMessage?: string;
+}
+
+export function TabList({ tabs, onOpen, onDelete, emptyMessage }: TabListProps) {
+  return (
+    <div className="max-h-96 overflow-y-auto text-xs border rounded divide-y">
+      {tabs.map((tab) => (
+        <div key={tab.id} className="flex items-center gap-2 py-1.5 px-2 hover:bg-muted">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <Favicon url={tab.url} />
+            <span className="truncate max-w-[200px]">{tab.title || new URL(tab.url).hostname}</span>
+            <span className="truncate max-w-[180px] text-muted-foreground">
+              {truncateUrl(tab.url)}
+            </span>
+            <div className="flex items-center gap-1">
+              {tab.tags.map((tag) => (
+                <Badge key={tag} variant="secondary" className="px-1.5 py-0 text-[10px] rounded-full">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            <span>{tab.status === 'read' ? '✔️' : ''}</span>
+            <button
+              aria-label="Open tab"
+              onClick={() => onOpen(tab.url)}
+              className="hover:text-primary"
+            >
+              🔗
+            </button>
+            <button
+              aria-label="Delete tab"
+              onClick={() => onDelete(tab.id)}
+              className="hover:text-destructive"
+            >
+              ❌
+            </button>
+          </div>
+        </div>
+      ))}
+      {tabs.length === 0 && (
+        <p className="p-4 text-center text-muted-foreground">
+          {emptyMessage || 'No tabs found.'}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function truncateUrl(url: string, max = 50) {
+  const stripped = url.replace(/^https?:\/\//, '');
+  return stripped.length > max ? `${stripped.slice(0, max)}…` : stripped;
+}
+
+function Favicon({ url }: { url: string }) {
+  const [error, setError] = useState(false);
+  const domain = new URL(url).hostname;
+  if (error) {
+    return <span className="w-4 h-4 flex items-center justify-center">📄</span>;
+  }
+  return (
+    <img
+      src={`https://www.google.com/s2/favicons?domain=${domain}`}
+      alt=""
+      className="w-4 h-4 flex-shrink-0"
+      onError={() => setError(true)}
+    />
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, FormEvent } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
@@ -6,18 +6,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { toast } from '@/hooks/use-toast';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { TabList } from '@/components/TabList';
 import {
   LogOut,
-  Plus,
-  ExternalLink,
-  Trash2,
-  Check,
-  X,
-  Archive
+  Plus
 } from 'lucide-react';
 
 interface SavedTab {
@@ -87,7 +82,7 @@ export default function Dashboard() {
    *
    * @param e - Form submission event.
    */
-  const handleAddTab = async (e: React.FormEvent) => {
+  const handleAddTab = async (e: FormEvent) => {
     e.preventDefault();
     
     try {
@@ -297,70 +292,12 @@ export default function Dashboard() {
                 </div>
               </div>
 
-              <div className="border rounded divide-y">
-                {filteredTabs.filter(tab => tab.status === 'unread').map((tab) => (
-                  <div
-                    key={tab.id}
-                    className="flex items-center justify-between p-2 text-xs hover:bg-muted"
-                  >
-                    <div className="flex items-center gap-2 min-w-0">
-                      <img
-                        src={`https://www.google.com/s2/favicons?domain=${tab.domain}`}
-                        alt=""
-                        className="w-4 h-4"
-                      />
-                      <span className="truncate max-w-[160px]">{tab.title}</span>
-                      <span className="text-muted-foreground truncate max-w-[120px]">
-                        {tab.domain}
-                      </span>
-                      <div className="flex items-center gap-1">
-                        {tab.tags.slice(0, 3).map((tag) => (
-                          <Badge
-                            key={tag}
-                            variant="secondary"
-                            className="px-1 py-0 text-[10px]"
-                          >
-                            {tag}
-                          </Badge>
-                        ))}
-                        {tab.tags.length > 3 && (
-                          <span className="text-[10px] text-muted-foreground">
-                            +{tab.tags.length - 3}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      {tab.status === 'read' ? (
-                        <Check className="h-4 w-4 text-green-500" />
-                      ) : (
-                        <X className="h-4 w-4 text-red-500" />
-                      )}
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => window.open(tab.url, '_blank')}
-                        className="h-6 w-6"
-                      >
-                        <ExternalLink className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => deleteTab(tab.id)}
-                        className="h-6 w-6 text-destructive"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-                {filteredTabs.filter(tab => tab.status === 'unread').length === 0 && (
-                  <p className="p-4 text-center text-muted-foreground">
-                    No unread tabs in your queue!
-                  </p>
-                )}
-              </div>
+              <TabList
+                tabs={filteredTabs.filter(tab => tab.status === 'unread')}
+                onOpen={(url) => window.open(url, '_blank')}
+                onDelete={deleteTab}
+                emptyMessage="No unread tabs in your queue!"
+              />
             </div>
           </TabsContent>
 
@@ -390,72 +327,12 @@ export default function Dashboard() {
                 </div>
               </div>
 
-              <div className="border rounded divide-y">
-                {filteredTabs.map((tab) => (
-                  <div
-                    key={tab.id}
-                    className="flex items-center justify-between p-2 text-xs hover:bg-muted"
-                  >
-                    <div className="flex items-center gap-2 min-w-0">
-                      <img
-                        src={`https://www.google.com/s2/favicons?domain=${tab.domain}`}
-                        alt=""
-                        className="w-4 h-4"
-                      />
-                      <span className="truncate max-w-[160px]">{tab.title}</span>
-                      <span className="text-muted-foreground truncate max-w-[120px]">
-                        {tab.domain}
-                      </span>
-                      <div className="flex items-center gap-1">
-                        {tab.tags.slice(0, 3).map((tag) => (
-                          <Badge
-                            key={tag}
-                            variant="secondary"
-                            className="px-1 py-0 text-[10px]"
-                          >
-                            {tag}
-                          </Badge>
-                        ))}
-                        {tab.tags.length > 3 && (
-                          <span className="text-[10px] text-muted-foreground">
-                            +{tab.tags.length - 3}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      {tab.status === 'archived' ? (
-                        <Archive className="h-4 w-4 text-muted-foreground" />
-                      ) : tab.status === 'read' ? (
-                        <Check className="h-4 w-4 text-green-500" />
-                      ) : (
-                        <X className="h-4 w-4 text-red-500" />
-                      )}
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => window.open(tab.url, '_blank')}
-                        className="h-6 w-6"
-                      >
-                        <ExternalLink className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => deleteTab(tab.id)}
-                        className="h-6 w-6 text-destructive"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-                ))}
-                {filteredTabs.length === 0 && (
-                  <p className="p-4 text-center text-muted-foreground">
-                    No tabs found matching your criteria.
-                  </p>
-                )}
-              </div>
+              <TabList
+                tabs={filteredTabs}
+                onOpen={(url) => window.open(url, '_blank')}
+                onDelete={deleteTab}
+                emptyMessage="No tabs found matching your criteria."
+              />
             </div>
           </TabsContent>
         </Tabs>


### PR DESCRIPTION
## Summary
- replace dashboard tab mappings with new TabList component
- add TabList component for compact row-style tabs with favicon, title, URL, tags, and actions
- resolve TypeScript issues by switching to hook imports and FormEvent typings

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894e19bf67c832e8e5baa2ddbd3eb6b