### PR TITLE
Enlarge popup and shrink tab items for easier management

### DIFF
--- a/clear-tab-mind-extension/popup.css
+++ b/clear-tab-mind-extension/popup.css
@@ -15,8 +15,8 @@ body {
 }
 
 .popup-container {
-  width: 450px;
-  min-height: 600px;
+  width: 700px;
+  min-height: 800px;
   background: white;
   border-radius: 8px;
   overflow: hidden;
@@ -344,7 +344,7 @@ body {
 }
 
 .tabs-list {
-  max-height: 400px;
+  max-height: 600px;
   overflow-y: auto;
   margin-bottom: 16px;
 }
@@ -353,8 +353,8 @@ body {
   background: white;
   border: 1px solid #e9ecef;
   border-radius: 6px;
-  padding: 12px;
-  margin-bottom: 8px;
+  padding: 6px;
+  margin-bottom: 4px;
   transition: all 0.2s;
 }
 
@@ -374,17 +374,17 @@ body {
 }
 
 .tab-content h4 {
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 600;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
   color: #212529;
   line-height: 1.3;
 }
 
 .tab-url {
-  font-size: 12px;
+  font-size: 10px;
   color: #6c757d;
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   word-break: break-all;
 }
 
@@ -396,11 +396,11 @@ body {
   display: inline-block;
   background: #e9ecef;
   color: #495057;
-  padding: 2px 6px;
+  padding: 1px 4px;
   border-radius: 12px;
-  font-size: 11px;
+  font-size: 10px;
   margin-right: 4px;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
 }
 
 .note {

--- a/popup.css
+++ b/popup.css
@@ -15,8 +15,8 @@ body {
 }
 
 .popup-container {
-  width: 450px;
-  min-height: 600px;
+  width: 700px;
+  min-height: 800px;
   background: white;
   border-radius: 8px;
   overflow: hidden;
@@ -344,7 +344,7 @@ body {
 }
 
 .tabs-list {
-  max-height: 400px;
+  max-height: 600px;
   overflow-y: auto;
   margin-bottom: 16px;
 }
@@ -353,8 +353,8 @@ body {
   background: white;
   border: 1px solid #e9ecef;
   border-radius: 6px;
-  padding: 12px;
-  margin-bottom: 8px;
+  padding: 6px;
+  margin-bottom: 4px;
   transition: all 0.2s;
 }
 
@@ -374,17 +374,17 @@ body {
 }
 
 .tab-content h4 {
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 600;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
   color: #212529;
   line-height: 1.3;
 }
 
 .tab-url {
-  font-size: 12px;
+  font-size: 10px;
   color: #6c757d;
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   word-break: break-all;
 }
 
@@ -396,11 +396,11 @@ body {
   display: inline-block;
   background: #e9ecef;
   color: #495057;
-  padding: 2px 6px;
+  padding: 1px 4px;
   border-radius: 12px;
-  font-size: 11px;
+  font-size: 10px;
   margin-right: 4px;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
 }
 
 .note {


### PR DESCRIPTION
## Summary
- expand popup width and height to give more room for tab management
- compress tab list items and text to resemble compact file manager view

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68950103a9e4832ea1ea5dd325b71f06